### PR TITLE
SDL Joystick fixes

### DIFF
--- a/import/derelict/sdl2/functions.d
+++ b/import/derelict/sdl2/functions.d
@@ -166,7 +166,7 @@ extern(C)
     // SDL_joystick.h
     alias nothrow int function() da_SDL_NumJoysticks;
     alias nothrow const(char)* function(int) da_SDL_JoystickName;
-    alias nothrow SDL_Joystick* da_SDL_JoystickOpen;
+    alias nothrow SDL_Joystick* function(int) da_SDL_JoystickOpen;
     alias nothrow int function(int) da_SDL_JoystickOpened;
     alias nothrow int function(SDL_Joystick*) da_SDL_JoystickIndex;
     alias nothrow int function(SDL_Joystick*) da_SDL_JoystickNumAxes;

--- a/import/derelict/sdl2/types.d
+++ b/import/derelict/sdl2/types.d
@@ -361,6 +361,17 @@ struct SDL_JoyAxisEvent
     Uint32 type;
     Uint32 timestamp;
     Uint8 which;
+    Uint8 axis;
+    Uint8 padding1;
+    Uint8 padding2;
+    int value;
+}
+
+struct SDL_JoyBallEvent
+{
+    Uint32 type;
+    Uint32 timestamp;
+    Uint8 which;
     Uint8 ball;
     Uint8 padding1;
     Uint8 padding2;


### PR DESCRIPTION
In sdl2/types.d, struct SDL_JoyAxisEvent contains the wrong fields -- the ones that are there should be in struct SDL_JoyBallEvent, which is missing.

In sdl2/functions.d, da_SDL_JoystickOpen was missing the function(int) from its type.
