### PR TITLE
fixing typo from SDL_ISPIXELFORMAT_ALHPA to SDL_ISPIXELFORMAT_ALPHA

### DIFF
--- a/import/derelict/sdl2/types.d
+++ b/import/derelict/sdl2/types.d
@@ -1469,7 +1469,7 @@ bool SDL_ISPIXELFORMAT_INDEXED(Uint32 format)
     return false;
 }
 
-bool SDL_ISPIXELFORMAT_ALHPA(Uint32 format)
+bool SDL_ISPIXELFORMAT_ALPHA(Uint32 format)
 {
     if(!SDL_ISPIXELFORMAT_FOURCC(format))
     {


### PR DESCRIPTION
What says the title
