### PR TITLE
Added a few functions to win util functions

### DIFF
--- a/import/derelict/util/wintypes.d
+++ b/import/derelict/util/wintypes.d
@@ -218,7 +218,9 @@ version(Windows)
 
     extern(Windows)
     {
+        HDC GetDC(HWND);
         int ChoosePixelFormat(HDC,PIXELFORMATDESCRIPTOR*);
+        void SetPixelFormat(HDC,int,PIXELFORMATDESCRIPTOR*);
         int GetPixelFormat(HDC);
         int DescribePixelFormat(HDC,int,UINT,PIXELFORMATDESCRIPTOR*);
         BOOL SwapBuffers(HDC);


### PR DESCRIPTION
Manual GL context creation on windows still required Phobos for GetDC() and SetPixelFormat() which was a major pain. 

The real answer would be to add ChoosePixelFormat() and the missing constants to core.sys.windows.windows.d, but Derelict should probably reflect the current stable version of dmd in the meantime.
