### PR TITLE
Add search path of SDL2

### DIFF
--- a/import/derelict/sdl2/sdl.d
+++ b/import/derelict/sdl2/sdl.d
@@ -43,7 +43,7 @@ private
     else static if(Derelict_OS_Mac)
         enum libNames = "../Frameworks/SDL2.framework/SDL2, /Library/Frameworks/SDL2.framework/SDL2, /System/Library/Frameworks/SDL2.framework/SDL2";
     else static if(Derelict_OS_Posix)
-        enum libNames = "libSDL2.so,/usr/local/lib/libSDL2.so";
+        enum libNames = "./libSDL2.so,libSDL2.so,/usr/local/lib/libSDL2.so";
     else
         static assert(0, "Need to implement SDL2 libNames for this operating system.");
 }

--- a/import/derelict/sdl2/ttf.d
+++ b/import/derelict/sdl2/ttf.d
@@ -39,7 +39,7 @@ private
     else static if(Derelict_OS_Mac)
         enum libNames = "../Frameworks/SDL2_ttf.framework/SDL2_ttf, /Library/Frameworks/SDL2_ttf.framework/SDL2_ttf, /System/Library/Frameworks/SDL2_ttf.framework/SDL2_ttf";
     else static if(Derelict_OS_Posix)
-        enum libNames = "libSDL2_ttf.so";
+        enum libNames = "./libSDL2_ttf.so,libSDL2_ttf.so";
     else
         static assert(0, "Need to implement SDL2_ttf libNames for this operating system.");
 }


### PR DESCRIPTION
In linux unlike windows, DerelictSDL2 doesn't search shared libraries in the current directory.
This commit adds the current directory to the search path of shared libraries used by DerelictSDL2.
