### PR TITLE
Updated GLFW mouse function bindings.

### DIFF
--- a/import/derelict/glfw3/functions.d
+++ b/import/derelict/glfw3/functions.d
@@ -79,13 +79,13 @@ extern(C)
     alias nothrow void function(GLFWwindow, int, int)da_glfwSetInputMode;
     alias nothrow int function(GLFWwindow, int)da_glfwGetKey;
     alias nothrow int function(GLFWwindow, int)da_glfwGetMouseButton;
-    alias nothrow void function(GLFWwindow, int*, int*)da_glfwGetMousePos;
-    alias nothrow void function(GLFWwindow, int, int)da_glfwSetMousePos;
+    alias nothrow void function(GLFWwindow, int*, int*)da_glfwGetCursorPos;
+    alias nothrow void function(GLFWwindow, int, int)da_glfwSetCursorPos;
     alias nothrow void function(GLFWwindow, int*, int*)da_glfwGetScrollOffset;
     alias nothrow void function(GLFWkeyfun)da_glfwSetKeyCallback;
     alias nothrow void function(GLFWcharfun)da_glfwSetCharCallback;
     alias nothrow void function(GLFWmousebuttonfun)da_glfwSetMouseButtonCallback;
-    alias nothrow void function(GLFWmouseposfun)da_glfwSetMousePosCallback;
+    alias nothrow void function(GLFWcursorposfun)da_glfwSetCursorPosCallback;
     alias nothrow void function(GLFWscrollfun)da_glfwSetScrollCallback;
 
     alias nothrow int function(int, int)da_glfwGetJoystickParam;
@@ -143,13 +143,13 @@ __gshared
     da_glfwSetInputMode glfwSetInputMode;
     da_glfwGetKey glfwGetKey;
     da_glfwGetMouseButton glfwGetMouseButton;
-    da_glfwGetMousePos glfwGetMousePos;
-    da_glfwSetMousePos glfwSetMousePos;
+    da_glfwGetCursorPos glfwGetCursorPos;
+    da_glfwSetCursorPos glfwSetCursorPos;
     da_glfwGetScrollOffset glfwGetScrollOffset;
     da_glfwSetKeyCallback glfwSetKeyCallback;
     da_glfwSetCharCallback glfwSetCharCallback;
     da_glfwSetMouseButtonCallback glfwSetMouseButtonCallback;
-    da_glfwSetMousePosCallback glfwSetMousePosCallback;
+    da_glfwSetCursorPosCallback glfwSetCursorPosCallback;
     da_glfwSetScrollCallback glfwSetScrollCallback;
     da_glfwGetJoystickParam glfwGetJoystickParam;
     da_glfwGetJoystickPos glfwGetJoystickPos;

--- a/import/derelict/glfw3/glfw3.d
+++ b/import/derelict/glfw3/glfw3.d
@@ -91,13 +91,13 @@ class DerelictGLFW3Loader : SharedLibLoader
             bindFunc(cast(void**)&glfwSetInputMode, "glfwSetInputMode");
             bindFunc(cast(void**)&glfwGetKey, "glfwGetKey");
             bindFunc(cast(void**)&glfwGetMouseButton, "glfwGetMouseButton");
-            bindFunc(cast(void**)&glfwGetMousePos, "glfwGetMousePos");
-            bindFunc(cast(void**)&glfwSetMousePos, "glfwSetMousePos");
+            bindFunc(cast(void**)&glfwGetCursorPos, "glfwGetCursorPos");
+            bindFunc(cast(void**)&glfwSetCursorPos, "glfwSetCursorPos");
             bindFunc(cast(void**)&glfwGetScrollOffset, "glfwGetScrollOffset");
             bindFunc(cast(void**)&glfwSetKeyCallback, "glfwSetKeyCallback");
             bindFunc(cast(void**)&glfwSetCharCallback, "glfwSetCharCallback");
             bindFunc(cast(void**)&glfwSetMouseButtonCallback, "glfwSetMouseButtonCallback");
-            bindFunc(cast(void**)&glfwSetMousePosCallback, "glfwSetMousePosCallback");
+            bindFunc(cast(void**)&glfwSetCursorPosCallback, "glfwSetCursorPosCallback");
             bindFunc(cast(void**)&glfwSetScrollCallback, "glfwSetScrollCallback");
             bindFunc(cast(void**)&glfwGetJoystickParam, "glfwGetJoystickParam");
             bindFunc(cast(void**)&glfwGetJoystickPos, "glfwGetJoystickPos");

--- a/import/derelict/glfw3/types.d
+++ b/import/derelict/glfw3/types.d
@@ -292,7 +292,7 @@ extern(C)
     alias void function(GLFWwindow, int) GLFWwindowfocusfun;
     alias void function(GLFWwindow, int) GLFWwindowiconifyfun;
     alias void function(GLFWwindow, int, int) GLFWmousebuttonfun;
-    alias void function(GLFWwindow, int, int) GLFWmouseposfun;
+    alias void function(GLFWwindow, int, int) GLFWcursorposfun;
     alias void function(GLFWwindow, int, int) GLFWscrollfun;
     alias void function(GLFWwindow, int, int) GLFWkeyfun;
     alias void function(GLFWwindow, int) GLFWcharfun;


### PR DESCRIPTION
The [latest commit to GLFW](https://github.com/elmindreda/glfw/commit/cef9dea1d236100b1a4b0d41b698dcb2359175cc) changed the names of some of the mouse functions, breaking the bindings. I've replaced the respective declarations with the new names.
