### PR TITLE
Small bugfix for Assimp bindings.

### DIFF
--- a/import/derelict/assimp/types.d
+++ b/import/derelict/assimp/types.d
@@ -127,8 +127,8 @@ struct aiAnimation
 
 
 // aiMaterial.h
-const uint AI_MAX_NUMBER_OF_COLOR_SETS = 0x4;
-const uint AI_MAX_NUMBER_OF_TEXTURECOORDS = 0x4;
+const uint AI_MAX_NUMBER_OF_COLOR_SETS = 0x8;
+const uint AI_MAX_NUMBER_OF_TEXTURECOORDS = 0x8;
 
 enum aiTextureOp : uint
 {


### PR DESCRIPTION
A small fix for the bug discussed in issue #32. 

Some compile-time dimension variables were defined differently in the D bindings than in the Assimp 3 C header files. As a consequence of this, the memory layouts of some structures didn't match each other.

The corresponding C header file is this one:
https://github.com/assimp/assimp/blob/master/include/assimp/mesh.h
