### PR TITLE
Add missing GLFW_CLOSE_REQUESTED

### DIFF
--- a/import/derelict/glfw3/types.d
+++ b/import/derelict/glfw3/types.d
@@ -219,6 +219,7 @@ enum
 
     GLFW_ACTIVE               = 0x00020001,
     GLFW_ICONIFIED            = 0x00020002,
+    GLFW_CLOSE_REQUESTED      = 0x00020003,
     GLFW_OPENGL_REVISION      = 0x00020004,
 
     GLFW_RED_BITS             = 0x00021000,


### PR DESCRIPTION
The constant GLFW_CLOSE_REQUESTED from glfw3.h was not included in types.d.

It is used in conjunction with glfwGetWindowParam to determine whether the window should be closed, for example when the window receives a WM_CLOSE message on Windows.
