### PR TITLE
Added /usr/local/lib/ + libSDL2.dylib to libnames search path on Mac OS X

### DIFF
--- a/import/derelict/sdl2/sdl.d
+++ b/import/derelict/sdl2/sdl.d
@@ -41,7 +41,7 @@ private
     static if(Derelict_OS_Windows)
         enum libNames = "SDL2.dll";
     else static if(Derelict_OS_Mac)
-        enum libNames = "../Frameworks/SDL2.framework/SDL2, /Library/Frameworks/SDL2.framework/SDL2, /System/Library/Frameworks/SDL2.framework/SDL2";
+        enum libNames = "/usr/local/lib/libSDL2.dylib, ../Frameworks/SDL2.framework/SDL2, /Library/Frameworks/SDL2.framework/SDL2, /System/Library/Frameworks/SDL2.framework/SDL2";
     else static if(Derelict_OS_Posix)
         enum libNames = "libSDL2.so,/usr/local/lib/libSDL2.so";
     else


### PR DESCRIPTION
SDL2's (SDL HG) install script performs an installation into
/usr/local/bin/ by default and not the library/framework folder
(anymore?!). This behavior is regardless of building and installing
SDL2 through command line or Xcode.

Besides the path change I've provided also the file name incl. the file
extension. Providing only the folder path did not work for me (tested
on Mac OS X 10.8.1 - dmd 2.060 ).

Please note: libSDL2.dylib is just an alias for the actual file (The
actual file is called libSDL2-2.0.0.dylib).
