### PR TITLE
.gitignore modified: .DS_Store added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.so
 lib/*.lib
 lib/*.a
+.DS_Store


### PR DESCRIPTION
Mac OS X stores .DS_Store files to save folder's display
configuration in Finder. These files are not relevant for the project
an should be ignored by github to prevent clutter. 

This is useful for all mac os x users that want to fork derelict3.
