### PR TITLE
Update import/derelict/assimp/types.d

### DIFF
--- a/import/derelict/assimp/types.d
+++ b/import/derelict/assimp/types.d
@@ -29,7 +29,7 @@ module derelict.assimp.types;
 
 
 // assimp.h
-extern (C) nothrow alias void function(const char*, char*) aiLogStreamCallback;
+extern (C) nothrow alias void function(const(char)*, char*) aiLogStreamCallback;
 
 struct aiLogStream
 {
@@ -506,3 +506,14 @@ struct aiMemoryInfo
 const size_t MAXLEN = 1024;
 
 alias int aiBool;
+
+enum AI_FALSE = 0,
+     AI_TRUE = 1;
+
+
+// version.h
+enum ASSIMP_CFLAGS_SHARED = 0x1,
+     ASSIMP_CFLAGS_STLPORT = 0x2,
+     ASSIMP_CFLAGS_DEBUG = 0x4,
+     ASSIMP_CFLAGS_NOBOOST = 0x8,
+     ASSIMP_CFLAGS_SINGLETHREADED = 0x10;


### PR DESCRIPTION
Two Assimp tweaks:
- replace const char* by const(char)* to match C++'s const char*
- adding some missing constants with regards to current Assimp.
