### PR TITLE
Modified search path for libglfw.3.dylib for Mac OS X - import/derelict/glfw3/glfw3.d

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 lib/*.lib
 lib/*.a
 .DS_Store
+
+build/build
+build/build.o

--- a/import/derelict/assimp/types.d
+++ b/import/derelict/assimp/types.d
@@ -29,7 +29,7 @@ module derelict.assimp.types;
 
 
 // assimp.h
-extern (C) nothrow alias void function(const char*, char*) aiLogStreamCallback;
+extern (C) nothrow alias void function(const(char)*, char*) aiLogStreamCallback;
 
 struct aiLogStream
 {
@@ -506,3 +506,14 @@ struct aiMemoryInfo
 const size_t MAXLEN = 1024;
 
 alias int aiBool;
+
+enum AI_FALSE = 0,
+     AI_TRUE = 1;
+
+
+// version.h
+enum ASSIMP_CFLAGS_SHARED = 0x1,
+     ASSIMP_CFLAGS_STLPORT = 0x2,
+     ASSIMP_CFLAGS_DEBUG = 0x4,
+     ASSIMP_CFLAGS_NOBOOST = 0x8,
+     ASSIMP_CFLAGS_SINGLETHREADED = 0x10;

--- a/import/derelict/glfw3/glfw3.d
+++ b/import/derelict/glfw3/glfw3.d
@@ -41,7 +41,7 @@ private
     static if(Derelict_OS_Windows)
         enum libNames = "glfw3.dll";
     else static if(Derelict_OS_Mac)
-        enum libNames = "libglfw3.dylib";
+        enum libNames = "/usr/local/lib/libglfw.3.dylib,/usr/local/lib/libglfw.dylib,libglfw.3.dylib,libglfw.dylib";
     else static if(Derelict_OS_Posix)
         enum libNames = "libglfw3.so,libglfw.so.3,/usr/local/lib/libglfw3.so,/usr/local/lib/libglfw.so.3";
     else


### PR DESCRIPTION
Same as for SDL2: GLFW's build script installs the dylib into
"/usr/local/lib" on Mac OS X (10.8).

The default dylib name is libglfw.3.dylib - notice the dot before the
"3" - not libglfw3.dylib
