### PR TITLE
Build script: replaced 'packageName' with 'libName' to fix ldc2 build

### DIFF
--- a/build/build.d
+++ b/build/build.d
@@ -67,7 +67,7 @@ else version(LDC)
         version(Shared)
             return format("ldc2 %s -soname=%s.%s -I../import -of%s%s.%s %s", compilerOptions, libName, MajorVersion, outdir, libName, FullVersion, files);
         else
-            return format("ldc2 %s -I../import -of%s%sDerelict%s%s %s", compilerOptions, outdir, prefix, packageName, extension, files);
+            return format("ldc2 %s -I../import -of%s%sDerelict%s%s %s", compilerOptions, outdir, prefix, libName, extension, files);
     }
 }
 else


### PR DESCRIPTION
Attempting to compile build/build.d with ldc2 gave an error at line 70: 'undefined identifier: packageName'. Inferring from other cases where 'libName' was used, I renamed 'packageName' to 'libName' in the ldc2 case and it builds now.
