### PR TITLE
Build script: fixed ldc2 build for real this time

### DIFF
--- a/build/build.d
+++ b/build/build.d
@@ -67,7 +67,7 @@ else version(LDC)
         version(Shared)
             return format("ldc2 %s -soname=%s.%s -I../import -of%s%s.%s %s", compilerOptions, libName, MajorVersion, outdir, libName, FullVersion, files);
         else
-            return format("ldc2 %s -I../import -of%s%sDerelict%s%s %s", compilerOptions, outdir, prefix, libName, extension, files);
+            return format("ldc2 %s -I../import -of%s%s %s", compilerOptions, outdir, libName, files);
     }
 }
 else


### PR DESCRIPTION
Sorry about the last one. This one gets the library names correct.
