### PR TITLE
Removed glfwCopyContext

### DIFF
--- a/import/derelict/glfw3/functions.d
+++ b/import/derelict/glfw3/functions.d
@@ -104,7 +104,6 @@ extern(C)
     alias nothrow void function(int) da_glfwSwapInterval;
     alias nothrow int function(in char*) da_glfwExtensionSupported;
     alias nothrow void* function(in char*) da_glfwGetProcAddress;
-    alias nothrow void function(GLFWwindow, GLFWwindow, c_ulong) da_glfwCopyContext;
 }
 
 __gshared
@@ -166,5 +165,4 @@ __gshared
     da_glfwSwapInterval glfwSwapInterval;
     da_glfwExtensionSupported glfwExtensionSupported;
     da_glfwGetProcAddress glfwGetProcAddress;
-    da_glfwCopyContext glfwCopyContext;
 }

--- a/import/derelict/glfw3/glfw3.d
+++ b/import/derelict/glfw3/glfw3.d
@@ -111,7 +111,6 @@ class DerelictGLFW3Loader : SharedLibLoader
             bindFunc(cast(void**)&glfwSwapInterval, "glfwSwapInterval");
             bindFunc(cast(void**)&glfwExtensionSupported, "glfwExtensionSupported");
             bindFunc(cast(void**)&glfwGetProcAddress, "glfwGetProcAddress");
-            bindFunc(cast(void**)&glfwCopyContext, "glfwCopyContext");
         }
     }
     public


### PR DESCRIPTION
... as required by the glfw 3 API update from Nov. 22nd 2012.
