### PR TITLE
Support for EXT_framebuffer_object

### DIFF
--- a/import/derelict/opengl3/arb.d
+++ b/import/derelict/opengl3/arb.d
@@ -2282,6 +2282,135 @@ private void load_ARB_texture_storage()
     }
 }
 
+// EXT_framebuffer_object
+enum : uint
+{
+    GL_FRAMEBUFFER_EXT =                                   0x8D40,
+    GL_RENDERBUFFER_EXT =                                  0x8D41,
+    GL_STENCIL_INDEX1_EXT =                                0x8D46,
+    GL_STENCIL_INDEX4_EXT =                                0x8D47,
+    GL_STENCIL_INDEX8_EXT =                                0x8D48,
+    GL_STENCIL_INDEX16_EXT =                               0x8D49,
+    GL_RENDERBUFFER_WIDTH_EXT =                            0x8D42,
+    GL_RENDERBUFFER_HEIGHT_EXT =                           0x8D43,
+    GL_RENDERBUFFER_INTERNAL_FORMAT_EXT =                  0x8D44,
+    GL_RENDERBUFFER_RED_SIZE_EXT =                         0x8D50,
+    GL_RENDERBUFFER_GREEN_SIZE_EXT =                       0x8D51,
+    GL_RENDERBUFFER_BLUE_SIZE_EXT =                        0x8D52,
+    GL_RENDERBUFFER_ALPHA_SIZE_EXT =                       0x8D53,
+    GL_RENDERBUFFER_DEPTH_SIZE_EXT =                       0x8D54,
+    GL_RENDERBUFFER_STENCIL_SIZE_EXT =                     0x8D55,  
+    GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE_EXT =            0x8CD0,
+    GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME_EXT =            0x8CD1,
+    GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL_EXT =          0x8CD2,
+    GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE_EXT =  0x8CD3,
+    GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_3D_ZOFFSET_EXT =     0x8CD4,
+    GL_COLOR_ATTACHMENT0_EXT =                             0x8CE0,
+    GL_COLOR_ATTACHMENT1_EXT =                             0x8CE1,
+    GL_COLOR_ATTACHMENT2_EXT =                             0x8CE2,
+    GL_COLOR_ATTACHMENT3_EXT =                             0x8CE3,
+    GL_COLOR_ATTACHMENT4_EXT =                             0x8CE4,
+    GL_COLOR_ATTACHMENT5_EXT =                             0x8CE5,
+    GL_COLOR_ATTACHMENT6_EXT =                             0x8CE6,
+    GL_COLOR_ATTACHMENT7_EXT =                             0x8CE7,
+    GL_COLOR_ATTACHMENT8_EXT =                             0x8CE8,
+    GL_COLOR_ATTACHMENT9_EXT =                             0x8CE9,
+    GL_COLOR_ATTACHMENT10_EXT =                            0x8CEA,
+    GL_COLOR_ATTACHMENT11_EXT =                            0x8CEB,
+    GL_COLOR_ATTACHMENT12_EXT =                            0x8CEC,
+    GL_COLOR_ATTACHMENT13_EXT =                            0x8CED,
+    GL_COLOR_ATTACHMENT14_EXT =                            0x8CEE,
+    GL_COLOR_ATTACHMENT15_EXT =                            0x8CEF,
+    GL_DEPTH_ATTACHMENT_EXT =                              0x8D00,
+    GL_STENCIL_ATTACHMENT_EXT =                            0x8D20,
+    GL_FRAMEBUFFER_COMPLETE_EXT =                          0x8CD5,
+    GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT_EXT =             0x8CD6,
+    GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT_EXT =     0x8CD7,
+    GL_FRAMEBUFFER_INCOMPLETE_DIMENSIONS_EXT =             0x8CD9,
+    GL_FRAMEBUFFER_INCOMPLETE_FORMATS_EXT =                0x8CDA,
+    GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER_EXT =            0x8CDB,
+    GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER_EXT =            0x8CDC,
+    GL_FRAMEBUFFER_UNSUPPORTED_EXT =                       0x8CDD,
+    GL_FRAMEBUFFER_BINDING_EXT =                           0x8CA6,
+    GL_RENDERBUFFER_BINDING_EXT =                          0x8CA7,
+    GL_MAX_COLOR_ATTACHMENTS_EXT =                         0x8CDF,
+    GL_MAX_RENDERBUFFER_SIZE_EXT =                         0x84E8,
+    GL_INVALID_FRAMEBUFFER_OPERATION_EXT =                 0x0506,
+}
+
+extern(System)
+{
+    alias nothrow bool function(GLuint) da_glIsRenderbufferEXT;
+    alias nothrow void function(GLenum, GLuint) da_glBindRenderbufferEXT;
+    alias nothrow void function(GLsizei, const GLuint *) da_glDeleteRenderbuffersEXT;
+    alias nothrow void function(GLsizei, GLuint *) da_glGenRenderbuffersEXT;
+    alias nothrow void function(GLenum, GLenum, GLsizei, GLsizei) da_glRenderbufferStorageEXT;
+    alias nothrow void function(GLenum, GLenum, GLint *) da_glGetRenderbufferParameterivEXT;
+    alias nothrow bool function(GLuint) da_glIsFramebufferEXT;
+    alias nothrow void function(GLenum, GLuint) da_glBindFramebufferEXT;
+    alias nothrow void function(GLsizei, const GLuint *) da_glDeleteFramebuffersEXT;
+    alias nothrow void function(GLsizei, GLuint *) da_glGenFramebuffersEXT;
+    alias nothrow GLenum function(GLenum) da_glCheckFramebufferStatusEXT;
+    alias nothrow void function(GLenum, GLenum, GLenum, GLuint, GLint) da_glFramebufferTexture1DEXT;
+    alias nothrow void function(GLenum, GLenum, GLenum, GLuint, GLint) da_glFramebufferTexture2DEXT;
+    alias nothrow void function(GLenum, GLenum, GLenum, GLuint, GLint, GLint) da_glFramebufferTexture3DEXT;
+    alias nothrow void function(GLenum, GLenum, GLenum, GLuint) da_glFramebufferRenderbufferEXT;
+    alias nothrow void function(GLenum, GLenum, GLenum, GLint *) da_glGetFramebufferAttachmentParameterivEXT;
+    alias nothrow void function(GLenum) da_glGenerateMipmapEXT;    
+}
+
+__gshared
+{
+    da_glIsRenderbufferEXT glIsRenderbufferEXT;
+    da_glBindRenderbufferEXT glBindRenderbufferEXT;
+    da_glDeleteRenderbuffersEXT glDeleteRenderbuffersEXT;
+    da_glGenRenderbuffersEXT glGenRenderbuffersEXT;
+    da_glRenderbufferStorageEXT glRenderbufferStorageEXT;
+    da_glGetRenderbufferParameterivEXT glGetRenderbufferParameterivEXT;
+    da_glIsFramebufferEXT glIsFramebufferEXT;
+    da_glBindFramebufferEXT glBindFramebufferEXT;
+    da_glDeleteFramebuffersEXT glDeleteFramebuffersEXT;
+    da_glGenFramebuffersEXT glGenFramebuffersEXT;
+    da_glCheckFramebufferStatusEXT glCheckFramebufferStatusEXT;
+    da_glFramebufferTexture1DEXT glFramebufferTexture1DEXT;
+    da_glFramebufferTexture2DEXT glFramebufferTexture2DEXT;
+    da_glFramebufferTexture3DEXT glFramebufferTexture3DEXT;
+    da_glFramebufferRenderbufferEXT glFramebufferRenderbufferEXT;
+    da_glGetFramebufferAttachmentParameterivEXT glGetFramebufferAttachmentParameterivEXT;
+    da_glGenerateMipmapEXT glGenerateMipmapEXT;
+}
+
+private __gshared bool _EXT_framebuffer_object;
+bool EXT_framebuffer_object() @property { return _EXT_framebuffer_object; }
+private void load_EXT_framebuffer_object()
+{
+    try
+    {
+        bindGLFunc(cast(void**)&glIsRenderbufferEXT, "glIsRenderbufferEXT");
+        bindGLFunc(cast(void**)&glBindRenderbufferEXT, "glBindRenderbufferEXT");
+        bindGLFunc(cast(void**)&glDeleteRenderbuffersEXT, "glDeleteRenderbuffersEXT");
+        bindGLFunc(cast(void**)&glGenRenderbuffersEXT, "glGenRenderbuffersEXT");
+        bindGLFunc(cast(void**)&glRenderbufferStorageEXT, "glRenderbufferStorageEXT");
+        bindGLFunc(cast(void**)&glGetRenderbufferParameterivEXT, "glGetRenderbufferParameterivEXT");
+        bindGLFunc(cast(void**)&glIsFramebufferEXT, "glIsFramebufferEXT");
+        bindGLFunc(cast(void**)&glBindFramebufferEXT, "glBindFramebufferEXT");
+        bindGLFunc(cast(void**)&glDeleteFramebuffersEXT, "glDeleteFramebuffersEXT");
+        bindGLFunc(cast(void**)&glGenFramebuffersEXT, "glGenFramebuffersEXT");
+        bindGLFunc(cast(void**)&glCheckFramebufferStatusEXT, "glCheckFramebufferStatusEXT");
+        bindGLFunc(cast(void**)&glFramebufferTexture1DEXT, "glFramebufferTexture1DEXT");
+        bindGLFunc(cast(void**)&glFramebufferTexture2DEXT, "glFramebufferTexture2DEXT");
+        bindGLFunc(cast(void**)&glFramebufferTexture3DEXT, "glFramebufferTexture3DEXT");
+        bindGLFunc(cast(void**)&glFramebufferRenderbufferEXT, "glFramebufferRenderbufferEXT");
+        bindGLFunc(cast(void**)&glGetFramebufferAttachmentParameterivEXT, "glGetFramebufferAttachmentParameterivEXT");
+        bindGLFunc(cast(void**)&glGenerateMipmapEXT, "glGenerateMipmapEXT");
+        _EXT_framebuffer_object = true;
+    }
+    catch(Exception e)
+    {
+        _EXT_framebuffer_object = false;
+    }
+}
+
 package void loadARB(GLVersion glversion)
 {
     if(glversion >= GLVersion.GL30)
@@ -2453,5 +2582,8 @@ package void loadARB(GLVersion glversion)
         _ARB_shading_language_packing = isExtSupported(glversion, "GL_ARB_shading_language_packing");
         _ARB_texture_storage = isExtSupported(glversion, "GL_ARB_texture_storage");
         if(_ARB_texture_storage) load_ARB_texture_storage();
+
+        _EXT_framebuffer_object = isExtSupported(glversion, "GL_EXT_framebuffer_object");
+        if(_EXT_framebuffer_object) load_EXT_framebuffer_object();
     }
 }


### PR DESCRIPTION
I haven't found bindings for this usefull extention. I didn't dare to create separate module for non arb extentions, thats why i placed code into arb.d.
Bindings based on this http://www.opengl.org/registry/specs/EXT/framebuffer_object.txt specifications.
