### PR TITLE
Removed glfwGetError and glfwErrorString

### DIFF
--- a/import/derelict/glfw3/functions.d
+++ b/import/derelict/glfw3/functions.d
@@ -41,8 +41,6 @@ extern(C)
     alias nothrow void function(int*, int*, int*) da_glfwGetVersion;
     alias nothrow const(char)* function() da_glfwGetVersionString;
 
-    alias nothrow int function() da_glfwGetError;
-    alias nothrow const(char)* function(int) da_glfwErrorString;
     alias nothrow void function(GLFWerrorfun) da_glfwSetErrorCallback;
 
     alias nothrow GLFWvidmode* function(int) da_glfwGetVideoModes;
@@ -113,8 +111,6 @@ __gshared
     da_glfwTerminate glfwTerminate;
     da_glfwGetVersion glfwGetVersion;
     da_glfwGetVersionString glfwGetVersionString;
-    da_glfwGetError glfwGetError;
-    da_glfwErrorString glfwErrorString;
     da_glfwSetErrorCallback glfwSetErrorCallback;
     da_glfwGetVideoModes glfwGetVideoModes;
     da_glfwGetDesktopMode glfwGetDesktopMode;

--- a/import/derelict/glfw3/glfw3.d
+++ b/import/derelict/glfw3/glfw3.d
@@ -58,8 +58,6 @@ class DerelictGLFW3Loader : SharedLibLoader
             bindFunc(cast(void**)&glfwTerminate, "glfwTerminate");
             bindFunc(cast(void**)&glfwGetVersion, "glfwGetVersion");
             bindFunc(cast(void**)&glfwGetVersionString, "glfwGetVersionString");
-            bindFunc(cast(void**)&glfwGetError, "glfwGetError");
-            bindFunc(cast(void**)&glfwErrorString, "glfwErrorString");
             bindFunc(cast(void**)&glfwSetErrorCallback, "glfwSetErrorCallback");
             bindFunc(cast(void**)&glfwGetVideoModes, "glfwGetVideoModes");
             bindFunc(cast(void**)&glfwGetDesktopMode, "glfwGetDesktopMode");


### PR DESCRIPTION
Removed glfwGetError and glfwErrorString as required by the GLFW 3 API update from Dec 29th, 2012.
