### PR TITLE
opengl 4.3 is now detected correctly

### DIFF
--- a/import/derelict/opengl3/gl3.d
+++ b/import/derelict/opengl3/gl3.d
@@ -761,7 +761,9 @@ class DerelictGL3Loader : SharedLibLoader
         GLVersion findMaxAvailable()
         {
             string verstr = to!string(glGetString(GL_VERSION));
-            if(verstr.indexOf("4.2") != -1)
+            if(verstr.indexOf("4.3") != -1)
+                return GLVersion.HighestSupported;
+            else if(verstr.indexOf("4.2") != -1)
                 return GLVersion.GL42;
             else if(verstr.indexOf("4.1") != -1)
                 return GLVersion.GL41;


### PR DESCRIPTION
There is OpenGL 4.3 now for a while:

`glGetString(GL_VERSION)` returns `4.3.0 NVIDIA 310.19`, which makes your version detection fail, since this string contains `3.0`, so it loads OpenGL 3.0 instead of 4.2.
