### PR TITLE
Removes std.string.indexOf in favour of std.algorithm.canFind

### DIFF
--- a/import/derelict/opengl3/gl3.d
+++ b/import/derelict/opengl3/gl3.d
@@ -38,8 +38,8 @@ public
 
 private
 {
+    import std.algorithm;
     import std.conv;
-    import std.string;
 
     import derelict.util.loader;
     import derelict.util.exception;
@@ -761,35 +761,35 @@ class DerelictGL3Loader : SharedLibLoader
         GLVersion findMaxAvailable()
         {
             string verstr = to!string(glGetString(GL_VERSION));
-            if(verstr.indexOf("4.3") != -1)
+            if(verstr.canFind("4.3"))
                 return GLVersion.HighestSupported;
-            else if(verstr.indexOf("4.2") != -1)
+            else if(verstr.canFind("4.2"))
                 return GLVersion.GL42;
-            else if(verstr.indexOf("4.1") != -1)
+            else if(verstr.canFind("4.1"))
                 return GLVersion.GL41;
-            else if(verstr.indexOf("4.0") != -1)
+            else if(verstr.canFind("4.0"))
                 return GLVersion.GL40;
-            else if(verstr.indexOf("3.3") != -1)
+            else if(verstr.canFind("3.3"))
                 return GLVersion.GL33;
-            else if(verstr.indexOf("3.2") != -1)
+            else if(verstr.canFind("3.2"))
                 return GLVersion.GL32;
-            else if(verstr.indexOf("3.1") != -1)
+            else if(verstr.canFind("3.1"))
                 return GLVersion.GL31;
-            else if(verstr.indexOf("3.0") != -1)
+            else if(verstr.canFind("3.0"))
                 return GLVersion.GL30;
-            else if(verstr.indexOf("2.1") != -1)
+            else if(verstr.canFind("2.1"))
                 return GLVersion.GL21;
-            else if(verstr.indexOf("2.0") != -1)
+            else if(verstr.canFind("2.0"))
                 return GLVersion.GL20;
-            else if(verstr.indexOf("1.5") != -1)
+            else if(verstr.canFind("1.5"))
                 return GLVersion.GL15;
-            else if(verstr.indexOf("1.4") != -1)
+            else if(verstr.canFind("1.4"))
                 return GLVersion.GL14;
-            else if(verstr.indexOf("1.3") != -1)
+            else if(verstr.canFind("1.3"))
                 return GLVersion.GL13;
-            else if(verstr.indexOf("1.2") != -1)
+            else if(verstr.canFind("1.2"))
                 return GLVersion.GL12;
-            else if(verstr.indexOf("1.1") != -1)
+            else if(verstr.canFind("1.1"))
                 return GLVersion.GL11;
 
             // assume new version of OpenGL


### PR DESCRIPTION
The use of canFind instead of indexOf is more idiomatic.

Not exactly a necessary commit, just something that popped up and irked me while I was snooping around.
