### PR TITLE
DUB Package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "Derelict3",
+	"description": "A collection of dynamic D bindings to C libraries, useful for multimedia and game development.",
+	"homepage": "https://github.com/aldacron/Derelict3",
+	"copyright": "Copyright © 2012, Mike Parker",
+    "license": "Boost",
+    "targetType": "library",
+    "targetName": "Derelict3",
+    "targetPath": "lib",
+    "sourcePaths": ["import"],
+    "dflags": ["-O", "-w", "-release"],
+	"authors": [
+		"Mike Parker"
+	],
+	"dependencies": {
+	}
+}


### PR DESCRIPTION
Adds a package.json file for DUB. Currently it builds everything as one big static lib. Which will have to do until DUB adds support for multiple packages in one repo or something like that. However I think what DUB does when you've listed a package as a dependency for your project it will basically just put the .d files on the import scope so you'll really in reality only link to what you use (unless I'm mistaken of course). It probably only bigs the "giant" libDerelict3.a if you run dub build from project root. Again, I could be wrong. Just thought I'd save you the hassle of doing this on your own since I've already written plenty of package files!

Issue #96

Cheers!
