### PR TITLE
Added C linkage to Lua function aliases.

### DIFF
--- a/import/derelict/lua/types.d
+++ b/import/derelict/lua/types.d
@@ -57,10 +57,10 @@ const int LUA_ERRERR = 6;
 
 struct lua_State;
 
-alias int function(lua_State* L) lua_CFunction;
-alias const(char)* function(lua_State* L, void* ud, size_t* sz) lua_Reader;
-alias int function(lua_State* L, const(void)* p, size_t sz, void* ud) lua_Writer;
-alias void* function(void* ud, void* ptr, size_t osize, size_t nsize) lua_Alloc;
+alias extern(C) int function(lua_State* L) lua_CFunction;
+alias extern(C) const(char)* function(lua_State* L, void* ud, size_t* sz) lua_Reader;
+alias extern(C) int function(lua_State* L, const(void)* p, size_t sz, void* ud) lua_Writer;
+alias extern(C) void* function(void* ud, void* ptr, size_t osize, size_t nsize) lua_Alloc;
 
 const int LUA_TNONE = -1;
 const int LUA_TNIL = 0;


### PR DESCRIPTION
Hi,

It seems these linkages were missing. I've got a problem with a C function called in Lua and the given lua_State was not the same pointer as created before.
