### PR TITLE
Updated declaration of GLFWcursorposfun to latest version of glfw3

### DIFF
--- a/import/derelict/glfw3/types.d
+++ b/import/derelict/glfw3/types.d
@@ -300,7 +300,7 @@ extern(C)
     alias void function(GLFWwindow*, int) GLFWwindowfocusfun;
     alias void function(GLFWwindow*, int) GLFWwindowiconifyfun;
     alias void function(GLFWwindow*, int, int) GLFWmousebuttonfun;
-    alias void function(GLFWwindow*, int, int) GLFWcursorposfun;
+    alias void function(GLFWwindow*, double, double) GLFWcursorposfun;
     alias void function(GLFWwindow*, int) GLFWcursorenterfun;
     alias void function(GLFWwindow*, double, double) GLFWscrollfun;
     alias void function(GLFWwindow*, int, int) GLFWkeyfun;


### PR DESCRIPTION
In the latest version of glfw3, GLFWcursorposfun gets x and y as doubles:
https://github.com/elmindreda/glfw/blob/master/include/GL/glfw3.h#L691

Yet Derelict3 accepts them as ints:
alias void function(GLFWwindow*, int, int) GLFWcursorposfun;

This simply fixes the alias.
Running this test with the fixed alias gives correct results: https://gist.github.com/nguillemot/5411073
