### PR TITLE
fix compiler output on error.

### DIFF
--- a/build/build.d
+++ b/build/build.d
@@ -15,7 +15,7 @@ enum FullVersion  = MajorVersion ~"."~ MinorVersion ~"."~ BumpVersion;
 
 version(Windows)
 {
-    Enum prefix = "";
+    enum prefix = "";
     version(Shared) enum extension = ".dll";
     else enum extension = ".lib";
 }
@@ -177,8 +177,8 @@ void buildAll()
     try
     {
         foreach(key; pathMap.keys)
-	    buildPackage(key);
-	writeln("\nAll builds complete\n");
+            buildPackage(key);
+        writeln("\nAll builds complete\n");
     }
     // Eat any ErrnoException. The compiler will print the right thing on a failed build, no need
     // to clutter the output with exception info.
@@ -205,19 +205,19 @@ void buildSome(string[] args)
         // If any of the args matches a key in the pathMap, build
         // that package.
         foreach(s; args)
-	{
+        {
             if(!buildIt(s))
-	    {
+            {
                 s = s.toUpper();
                 if(!buildIt(s))
-		{
+                {
                     s = s.capitalize();
                     if(!buildIt(s))
-	                writefln("Unknown package '%s'", s);
-	        }
-	    }
+                        writefln("Unknown package '%s'", s);
+                }
+            }
         }
-	writeln("\nSelected builds complete\n");
+        writeln("\nSelected builds complete\n");
     }
     catch(ErrnoException e)
     {


### PR DESCRIPTION
Replacing the call to shell with a call to system allows the compiler output to be printed at all times. Previously shell would throw on error, meaning that it would not return the stdout to D, which would in turn not be printed.

Associated exception handling code is removed as system does not throw on an error code return.

Side effect: compilation of other modules continues if one fails.
