### PR TITLE
Update build.d

### DIFF
--- a/build/build.d
+++ b/build/build.d
@@ -101,7 +101,7 @@ else version(LDC)
     enum compilerOptions = "-lib -O -release -enable-inlining -property -w -wi";
     string buildCompileString(string files, string libName)
     {
-        return format("ldc2 %s -I%s -of%s/ldc%s %s", compilerOptions, importPath, outdir, libName, files);
+        return format("ldc2 %s -I%s -of%s/ldc/%s %s", compilerOptions, importPath, outdir, libName, files);
     }
 }
 else


### PR DESCRIPTION
Hello!
Just missing this char '/' else we get some ldclibDerelict\* as names of built libraries in the 'Derelict3/lib/' directory, instead of getting libraries in '/Derelict3/lib/ldc' (if we use ldc). 
