### PR TITLE
Fixes return type of alGetProcAddress and adds missing bindFunc for alGetSource3i

### DIFF
--- a/import/derelict/openal/al.d
+++ b/import/derelict/openal/al.d
@@ -102,6 +102,7 @@ class DerelictALLoader : SharedLibLoader
             bindFunc(cast(void**)&alGetSource3f, "alGetSource3f");
             bindFunc(cast(void**)&alGetSourcefv, "alGetSourcefv");
             bindFunc(cast(void**)&alGetSourcei, "alGetSourcei");
+            bindFunc(cast(void**)&alGetSource3i, "alGetSource3i");
             bindFunc(cast(void**)&alGetSourceiv, "alGetSourceiv");
 
             bindFunc(cast(void**)&alSourcePlayv, "alSourcePlayv");

--- a/import/derelict/openal/functions.d
+++ b/import/derelict/openal/functions.d
@@ -50,7 +50,7 @@ extern(C)
     alias nothrow ALenum function() da_alGetError;
 
     alias nothrow ALboolean function(in char*) da_alIsExtensionPresent;
-    alias nothrow ALboolean function(in char*) da_alGetProcAddress;
+    alias nothrow ALvoid* function(in char*) da_alGetProcAddress;
     alias nothrow ALenum function(in char*) da_alGetEnumValue;
 
     alias nothrow void function(ALenum, ALfloat) da_alListenerf;


### PR DESCRIPTION
The title says it all.
