### PR TITLE
New readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -184,6 +184,7 @@ Please bear in mind that this is all in an ALPHA state. It's perfectly usable as
 
 ##Derelict 1 & 2
 Project page: http://www.dsource.org/projects/derelict/
+
 Old forum: http://www.dsource.org/forums/viewforum.php?f=19
 
 #####Major changes from 2 -> 3

--- a/README.markdown
+++ b/README.markdown
@@ -3,47 +3,37 @@
 ###Dynamic D bindings to C libraries for multimedia and game development.
 
 ######Derelict 3 contains bindings to the following libraries (click the links for more info):
-* [Alure](http://kcat.strangesoft.net/alure.html)
-* [Assimp](http://assimp.sourceforge.net/)
-* [Assimp3](http://assimp.sourceforge.net/)
-* [Devil](http://openil.sourceforge.net/)
-* [Freeglut](http://freeglut.sourceforge.net/)
-* [Freeimage](http://freeimage.sourceforge.net/)
-* [Freetype](http://www.freetype.org/)
-* [Glfw3](http://www.glfw.org/)
-* [Lua](http://www.lua.org/)
-* [Ode](http://www.ode.org/)
-* [Ogg](http://xiph.org/ogg/)[Vorbis](http://xiph.org/vorbis/)
-* [Openal](http://connect.creativelabs.com/openal/)
-* [Opengl3](http://www.opengl.org/)
-* [physfs](http://icculus.org/physfs/)
-* [Pq](http://www.postgresql.org/download/)
-* [Sdl2](http://www.libsdl.org/)
-* [Sfml2](http://www.sfml-dev.org/)
-* [Tcod](http://doryen.eptalys.net/libtcod/)
+* [Alure](#alure)
+* [Assimp](#assimp)
+* [Assimp3](#assimp3)
+* [Devil](#devil)
+* [Freeglut](#freeglut)
+* [Freeimage](#freeimage)
+* [Freetype](#freetype)
+* [Glfw3](#glfw3)
+* [Lua](#lua)
+* [Ode](#ode)
+* [Ogg Vorbis](#ogg-vorbis)
+* [Openal](#openal)
+* [Opengl3](#opengl3)
+* [physfs](#physfs)
+* [Pq](#pq)
+* [Sdl2](#sdl2)
+* [Sfml2](#sfml2)
+* [Tcod](#tcod)
 
-as well as an internal utility library names [util](#util).
+as well as an internal utility library named [util](#util).
 
-####The Forum
+Derelict 3 should be considered as an alpha version. For the older Derelict 1 and 2 see [here](#derelict-1--2)
+
+###The Forum
 Visit for help, suggestions and discussion:
 http://dblog.aldacron.net/forum/index.php
 
-Consider the current repo an ALPHA version! If you don't know what Derelict is, see the old project page for info on Derelict 1 & 2:
+###Build
+Download the sources, either as a [zip](https://github.com/aldacron/Derelict3/archive/master.zip) or via git e.g. ```git clone https://github.com/aldacron/Derelict3.git```
 
-http://www.dsource.org/projects/derelict/
-
-
-The old forum also has a lot of information (when the site works):
-http://www.dsource.org/forums/viewforum.php?f=19
-
-This is a quick & dirty intro until I get the time to put together proper documentation. Several things have changed from Derelict 2.
-
-The first thing to notice is that all source modules are located under a single import tree. When you build, .di files are no longer generated. So when building your app, you can just put the 'import' folder on the compiler's import path and away you go.
-
-Second, Derelict is now D2 only. You should still be able to use Tango with Derelict via the recently announced D2 port. But if you need D1, go back to Derelict 2.
-
-Third, the build process has changed. No more makefiles. I hate them with a passion. The decision to support D2-only made it practical to slap together a simple build script. You can specify which packages to build, or specify none to build all. You can compile it once with your D2 compiler (DMD, GDC, or LDC2) and execute it as often as you need to. You'll only need to recompile the build script if you pull down any changes to it from the repository.
-
+Where ```$Derelict``` is the path of the Derelict directory:
 ```
 cd $Derelict/build
 dmd build.d
@@ -57,9 +47,49 @@ build Util GL3
 # Package names are case insensitive
 build util gl3
 ```
-#DerelictGL3
 
-The interface to DerelictGL3 is a bit different from the old DerelictGL. The primary change is that none of the symbols deprecated in the modern OpenGL specifications are present. This binding is based solely on the C header, gl3.h. You can still use older versions of OpenGL, but none of the deprecated functions will be loaded.
+##The packages:
+
+###Alure
+http://kcat.strangesoft.net/alure.html
+
+###Assimp
+http://assimp.sourceforge.net/
+
+###Assimp3
+http://assimp.sourceforge.net/
+
+###Devil
+http://openil.sourceforge.net/
+
+###Freeglut
+This is a binding to [freeglut 2.8.0](http://freeglut.sourceforge.net/). It is largely complete, however it's missing the types for the font stuff. In the C headers, the font types are declared in a manner that I find a bit confusing. I need to dig into it a bit more to figure out exactly how to implement them on the D side.
+
+###Freeimage
+http://freeimage.sourceforge.net/
+
+###Freetype
+This is a binding to [freetype 2.4](http://www.freetype.org/). For Windows, there are some binaries available for download from external links off the FreeType site, but those are for older versions and will not load out of the box. You'll definitely need to download and compile the latest 2.4.x version.
+
+###Glfw3
+http://www.glfw.org/
+
+###Lua
+http://www.lua.org/
+
+###Ode
+http://www.ode.org/
+
+###Ogg Vorbis
+http://xiph.org/ogg/
+http://xiph.org/vorbis/
+
+###Openal
+http://connect.creativelabs.com/openal/
+
+###OpenGL3
+http://www.opengl.org/
+None of the symbols deprecated in the modern OpenGL specifications are present. This binding is based solely on the C header, gl3.h. You can still use older versions of OpenGL, but none of the deprecated functions will be loaded.
 
 Here's what you need to do in order to get up and running.
 
@@ -124,21 +154,43 @@ void someFunc()
 
 Notice that you are using the DerelictGL object, not the DerelictGL3 object in this case. You still need to link DerelictGL3.lib, as the DerelictGL stuff is compiled into the same library since it's part of the same package.
 
-#DerelictFreeGLUT
+###physfs
+http://icculus.org/physfs/
 
-This is a binding to [freeglut 2.8.0](http://freeglut.sourceforge.net/). It is largely complete, however it's missing the types for the font stuff. In the C headers, the font types are declared in a manner that I find a bit confusing. I need to dig into it a bit more to figure out exactly how to implement them on the D side.
+###Pq
+http://www.postgresql.org/download/
 
-#DerelictFT
+###Sdl2
+http://www.libsdl.org/
 
-This is a binding to [freetype 2.4](http://www.freetype.org/). For Windows, there are some binaries available for download from external links off the FreeType site, but those are for older versions and will not load out of the box. You'll definitely need to download and compile the latest 2.4.x version.
+###Sfml2
+http://www.sfml-dev.org/
 
-#DerelictTCOD
-
-This is a binding to [libtcod 1.5.1](http://doryen.eptalys.net/libtcod/download/). Everything from libtcod is there with one major caveat. libtcod exports color structs from the shared library by value. This is no problem when linking with an import lib on windows or directly with the shared object on posix systems, but when loading manually like Derelict does it's rather problematic. libtcod provides some special functions, declared in "wrapper.h" for wrappers and bindings to work around the issue, but that means using integer values rather than the struct to represent colors. However, I chose to take a different route. DerelictTCOD loads the colors in the same way it loads the functions keep them stored as pointers. It would be possible to instead write a wrapper function that pulls the value from the pointer and copies it into the Derelict address space. But rather than do that sort of pointless duplication, I just kept them as pointers. In D, after all, you access members of a struct pointer in the same way you do a non-pointer. The only difference is that when you call one of the many TCOD_color* functions that expect a color struct to be passed by value and want to pass it one of the stock colors, you have to use the * operator on the color instance, like so:
+###Tcod
+This is a binding to [libtcod 1.5.1](http://doryen.eptalys.net/libtcod). Everything from libtcod is there with one major caveat. libtcod exports color structs from the shared library by value. This is no problem when linking with an import lib on windows or directly with the shared object on posix systems, but when loading manually like Derelict does it's rather problematic. libtcod provides some special functions, declared in "wrapper.h" for wrappers and bindings to work around the issue, but that means using integer values rather than the struct to represent colors. However, I chose to take a different route. DerelictTCOD loads the colors in the same way it loads the functions keep them stored as pointers. It would be possible to instead write a wrapper function that pulls the value from the pointer and copies it into the Derelict address space. But rather than do that sort of pointless duplication, I just kept them as pointers. In D, after all, you access members of a struct pointer in the same way you do a non-pointer. The only difference is that when you call one of the many TCOD_color* functions that expect a color struct to be passed by value and want to pass it one of the stock colors, you have to use the * operator on the color instance, like so:
 
 ```D
 auto color = TCOD_color_subract(*TCOD_white, *TCOD_red);
 ```
-#Finally
+
+###Util
+Todo
+
+##Status of the project
 
 Please bear in mind that this is all in an ALPHA state. It's perfectly usable as is, but there needs to be more work done on the build script, testing on different platforms/compilers, and, of course, the addition of a few more packages. Pull requests for bugfixes and enhancements are extremely welcome. However, I make no promises about accepting pull requests that add new packages. I'll have to take a wait-and-see approach on that for now.
+
+
+
+##Derelict 1 & 2
+Project page: http://www.dsource.org/projects/derelict/
+Old forum: http://www.dsource.org/forums/viewforum.php?f=19
+
+#####Major changes from 2 -> 3
+Several things have changed from Derelict 2.
+
+The first thing to notice is that all source modules are located under a single import tree. When you build, .di files are no longer generated. So when building your app, you can just put the 'import' folder on the compiler's import path and away you go.
+
+Second, Derelict is now D2 only. You should still be able to use Tango with Derelict via the recently announced D2 port. But if you need D1, go back to Derelict 2.
+
+Third, the build process has changed. No more makefiles. I hate them with a passion. The decision to support D2-only made it practical to slap together a simple build script. See [here](#build)

--- a/README.markdown
+++ b/README.markdown
@@ -1,11 +1,37 @@
 #Derelict 3
 
+###Dynamic D bindings to C libraries for multimedia and game development.
+
+######Derelict 3 contains bindings to the following libraries (click the links for more info):
+* [Alure](http://kcat.strangesoft.net/alure.html)
+* [Assimp](http://assimp.sourceforge.net/)
+* [Assimp3](http://assimp.sourceforge.net/)
+* [Devil](http://openil.sourceforge.net/)
+* [Freeglut](http://freeglut.sourceforge.net/)
+* [Freeimage](http://freeimage.sourceforge.net/)
+* [Freetype](http://www.freetype.org/)
+* [Glfw3](http://www.glfw.org/)
+* [Lua](http://www.lua.org/)
+* [Ode](http://www.ode.org/)
+* [Ogg](http://xiph.org/ogg/)[Vorbis](http://xiph.org/vorbis/)
+* [Openal](http://connect.creativelabs.com/openal/)
+* [Opengl3](http://www.opengl.org/)
+* [physfs](http://icculus.org/physfs/)
+* [Pq](http://www.postgresql.org/download/)
+* [Sdl2](http://www.libsdl.org/)
+* [Sfml2](http://www.sfml-dev.org/)
+* [Tcod](http://doryen.eptalys.net/libtcod/)
+
+as well as an internal utility library names [util](#util).
+
+####The Forum
+Visit for help, suggestions and discussion:
+http://dblog.aldacron.net/forum/index.php
+
 Consider the current repo an ALPHA version! If you don't know what Derelict is, see the old project page for info on Derelict 1 & 2:
 
 http://www.dsource.org/projects/derelict/
 
-And visit the forum for help:
-http://dblog.aldacron.net/forum/index.php
 
 The old forum also has a lot of information (when the site works):
 http://www.dsource.org/forums/viewforum.php?f=19


### PR DESCRIPTION
Mostly a rearrangement of the old one.

Changes, amongst others:
List of bindings with internal links to details
section for details for every library
moved derelict 1&2 info to the bottom, with a link from the top.

It's clearer as to what the project offers while still being explicit about it being an alpha.

This would probably need filling out a bit (particularly the package sections) before merging.
