### PR TITLE
Add alternative filename for freeglut library on OSX

### DIFF
--- a/import/derelict/freeglut/glut.d
+++ b/import/derelict/freeglut/glut.d
@@ -41,7 +41,7 @@ private
     static if(Derelict_OS_Windows)
         enum libNames = "freeglut.dll";
     else static if(Derelict_OS_Mac)
-        enum libNames = "libfreeglut.dylib";
+        enum libNames = "libfreeglut.dylib,libglut.dylib";
     else static if(Derelict_OS_Posix)
         enum libNames = "libfreeglut.so";
     else


### PR DESCRIPTION
Homebrew installs freeglut with a `libglut.dylib` filename.

(Caveat: I'm new to D, new to Dub and new to Derelict, so it's highly likely that my pull request is misguided and / or wrong.)
