### PR TITLE
[GLFW3]: Add GLFW_KEY_UNKNOWN

### DIFF
--- a/import/derelict/glfw3/types.d
+++ b/import/derelict/glfw3/types.d
@@ -43,6 +43,7 @@ enum
 
 enum
 {
+    GLFW_KEY_UNKNOWN               = -1,
     GLFW_KEY_SPACE                 = 32,
     GLFW_KEY_APOSTROPHE            = 39,
     GLFW_KEY_COMMA                 = 44,


### PR DESCRIPTION
GLFW3 bindings missed enum GLFW_KEY_UNKOWN, described in [documentation ](http://www.glfw.org/docs/3.0/group__keys.html)
