### PR TITLE
assimp3: add defines and API functions from version.h

### DIFF
--- a/import/derelict/assimp3/assimp.d
+++ b/import/derelict/assimp3/assimp.d
@@ -99,6 +99,11 @@ class DerelictASSIMP3Loader : SharedLibLoader {
         bindFunc(cast(void**)&aiGetMaterialString, "aiGetMaterialString");
         bindFunc(cast(void**)&aiGetMaterialTextureCount, "aiGetMaterialTextureCount");
         bindFunc(cast(void**)&aiGetMaterialTexture, "aiGetMaterialTexture");
+        bindFunc(cast(void**)&aiGetLegalString, "aiGetLegalString");
+        bindFunc(cast(void**)&aiGetVersionMinor, "aiGetVersionMinor");
+        bindFunc(cast(void**)&aiGetVersionMajor, "aiGetVersionMajor");
+        bindFunc(cast(void**)&aiGetVersionRevision, "aiGetVersionRevision");
+        bindFunc(cast(void**)&aiGetCompileFlags, "aiGetCompileFlags");
     }
 
     public this() {

--- a/import/derelict/assimp3/functions.d
+++ b/import/derelict/assimp3/functions.d
@@ -88,6 +88,13 @@ extern( C ) nothrow {
     alias aiReturn function( const( aiMaterial)*, const( char )*, uint, uint, aiString* ) da_aiGetMaterialString;
     alias uint function( const( aiMaterial )*, aiTextureType ) da_aiGetMaterialTextureCount;
     alias aiReturn function( aiTextureType, uint, aiString*, aiTextureMapping* m=null, uint* uvindex = null, float* blend = null, aiTextureOp* op = null, aiTextureMapMode* mm = null, uint* flags = null ) da_aiGetMaterialTexture;
+
+    // version.h
+    alias nothrow const(char)* function() da_aiGetLegalString;
+    alias nothrow uint function() da_aiGetVersionMinor;
+    alias nothrow uint function() da_aiGetVersionMajor;
+    alias nothrow uint function() da_aiGetVersionRevision;
+    alias nothrow uint function() da_aiGetCompileFlags;
 }
 
 __gshared {
@@ -136,4 +143,9 @@ __gshared {
     da_aiGetMaterialString aiGetMaterialString;
     da_aiGetMaterialTextureCount aiGetMaterialTextureCount;
     da_aiGetMaterialTexture aiGetMaterialTexture;
+    da_aiGetLegalString aiGetLegalString;
+    da_aiGetVersionMinor aiGetVersionMinor;
+    da_aiGetVersionMajor aiGetVersionMajor;
+    da_aiGetVersionRevision aiGetVersionRevision;
+    da_aiGetCompileFlags aiGetCompileFlags;
 }

--- a/import/derelict/assimp3/types.d
+++ b/import/derelict/assimp3/types.d
@@ -147,6 +147,9 @@ struct aiPropertyStore {
 
 alias int aiBool;
 
+enum AI_FALSE = 0,
+     AI_TRUE = 1;
+
 // color4.h
 align(1) struct aiColor4D {
     float r, g, b, a;
@@ -547,3 +550,11 @@ struct aiMemoryInfo {
     uint lights;
     uint total;
 }
+
+// version.h
+
+enum ASSIMP_CFLAGS_SHARED = 0x1,
+     ASSIMP_CFLAGS_STLPORT = 0x2,
+     ASSIMP_CFLAGS_DEBUG = 0x4,
+     ASSIMP_CFLAGS_NOBOOST = 0x8,
+     ASSIMP_CFLAGS_SINGLETHREADED = 0x10;


### PR DESCRIPTION
In Assimp 3, cimport.h does not include version.h, however version.h does define API functions.
