### PR TITLE
Update functions.d

### DIFF
--- a/import/derelict/sdl2/functions.d
+++ b/import/derelict/sdl2/functions.d
@@ -439,7 +439,7 @@ extern(C)
     alias nothrow void function() da_SDL_VideoQuit;
     alias nothrow const(char)* function() da_SDL_GetCurrentVideoDriver;
     alias nothrow int function() da_SDL_GetNumVideoDisplays;
-    alias nothrow int function(int) da_SDL_GetDisplayName;
+    alias nothrow const(char)* function(int) da_SDL_GetDisplayName;
     alias nothrow int function(int, SDL_Rect*) da_SDL_GetDisplayBounds;
     alias nothrow int function(int) da_SDL_GetNumDisplayModes;
     alias nothrow int function(int, int, SDL_DisplayMode*) da_SDL_GetDisplayMode;


### PR DESCRIPTION
Changed SDL_GetDisplayName() return type to const(char)*, according to http://wiki.libsdl.org/SDL_GetDisplayName?highlight=%28\bCategoryVideo\b%29|%28CategoryEnum%29|%28CategoryStruct%29
